### PR TITLE
Allow users to enter paragraphs of text below Title and Message

### DIFF
--- a/media/as3/ZeroClipboardPdf.as
+++ b/media/as3/ZeroClipboardPdf.as
@@ -178,13 +178,14 @@ package {
 		{
 			var
 				pdf:PDF,
-				i:int, iLen:int,
+				i:int, iLen:int, j:int, jLen:int,
 				splitText:Array    = clipText.split("--/TableToolsOpts--\n"),
 				opts:Array         = splitText[0].split("\n"),
 				dataIn:Array       = splitText[1].split("\n"),
 				aColRatio:Array    = getProp( 'colWidth', opts ).split('\t'),
 				title:String       = getProp( 'title', opts ),
 				message:String     = getProp( 'message', opts ),
+				extras:Array       = getProp( 'extras', opts ).split('\r'),
 				orientation:String = getProp( 'orientation', opts ),
 				size:String        = getProp( 'size', opts ),
 				iPageWidth:int     = 0,
@@ -211,6 +212,14 @@ package {
 			if ( message != "" )
 			{
 				pdf.writeText(11, message+"\n");
+			}
+			
+			for ( j=0, jLen=extras.length ; j<jLen ; j++ )
+			{
+				if ( extras[j] != "" )
+				{
+					pdf.writeText(11, extras[j]+"\n");
+				}
 			}
 			
 			/* Data setup. Split up the headers, and then construct the columns */

--- a/media/js/TableTools.js
+++ b/media/js/TableTools.js
@@ -2139,10 +2139,12 @@ TableTools.BUTTONS = {
 		"sPdfOrientation": "portrait",
 		"sPdfSize": "A4",
 		"sPdfMessage": "",
+		"sPdfExtras": "",
 		"fnClick": function( nButton, oConfig, flash ) {
 			this.fnSetText( flash, 
 				"title:"+ this.fnGetTitle(oConfig) +"\n"+
 				"message:"+ oConfig.sPdfMessage +"\n"+
+				"extras:" + oConfig.sPdfExtras +"\n"+
 				"colWidth:"+ this.fnCalcColRatios(oConfig) +"\n"+
 				"orientation:"+ oConfig.sPdfOrientation +"\n"+
 				"size:"+ oConfig.sPdfSize +"\n"+


### PR DESCRIPTION
By setting sPdfExtras users can achieve paragraphs above the table by
separating paragraphs with '\r'
