### PR TITLE
Multiple backgrounds on collection click

### DIFF
--- a/media/js/TableTools.js
+++ b/media/js/TableTools.js
@@ -997,7 +997,7 @@ TableTools.prototype = {
 			} );
 			
 			this.dom.collection.collection = null;
-			this.dom.collection.background = null;
+			$("." + TableTools.classes.collection.background).remove()
 		}
 	},
 	


### PR DESCRIPTION
The `div.DTTT_collection_background` gets spawned multiple times (once per click) but when clicking away, only the last div disappears. The other divs will continue to block the user from interacting with the other elements on the page.

Remove all instances of the background on background click.
