### PR TITLE
Check if the browser supports Flash

### DIFF
--- a/media/js/TableTools.js
+++ b/media/js/TableTools.js
@@ -785,7 +785,7 @@ TableTools.prototype = {
 	{
 	  var nButton = this._fnButtonBase( oConfig, bCollectionButton );
 		
-		if ( oConfig.sAction.match(/flash/) )
+		if ( oConfig.sAction.match(/flash/) && this._fnHasFlash() )
 		{
 			this._fnFlashConfig( nButton, oConfig );
 		}
@@ -1278,7 +1278,26 @@ TableTools.prototype = {
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Flash button functions
 	 */
-	
+
+	/**
+	 * Detects if the browser supports Flash. No params needed.
+	 *  @method  _fnHasFlash
+	 *  @returns {boolean} Browser supports Flash
+	 *  @private
+	 */
+	 
+	"_fnHasFlash": function ()
+	{
+		var flashCapable = false;
+		try {
+			var fo = new ActiveXObject('ShockwaveFlash.ShockwaveFlash');
+			if(fo) flashCapable = true;
+		} catch(e) {
+			if(navigator.mimeTypes ["application/x-shockwave-flash"] != undefined) flashCapable = true;
+		}
+		return flashCapable;
+	},
+
 	/**
 	 * Configure a flash based button for interaction events
 	 *  @method  _fnFlashConfig


### PR DESCRIPTION
One function included: "_fnHasFlash"

returns a boolean:
- true if the browser supports Flash
- false if not

Then, I edited one statement of "_fnCreateButton" function. Target: not to create any Flash button if the browser does not support it.

Please, check it, it is very useful for mobile devices which does not support Flash... This way, every Flash button will be shown as text button.

Thanks to albertein for publishing this way to check Flash capabilities. See StackOverflow post: http://stackoverflow.com/questions/998245/how-can-i-detect-if-flash-is-installed-and-if-not-display-a-hidden-div-that-inf
