### PR TITLE
Make HTML Decode regex non greedy

### DIFF
--- a/src/TableTools.js
+++ b/src/TableTools.js
@@ -1793,7 +1793,7 @@ TableTools.prototype = {
 
 		var n = document.createElement('div');
 
-		return sData.replace( /&([^\s]*);/g, function( match, match2 ) {
+		return sData.replace( /&([^\s]*?);/g, function( match, match2 ) {
 			if ( match.substr(1, 1) === '#' )
 			{
 				return String.fromCharCode( Number(match2.substr(1)) );


### PR DESCRIPTION
Using the current master HEAD, I had an issue decoding strings which contained multiple HTML entity codes e.g. '&#39;192.168.0.1&#39;'

I tracked the issue down to a malfunctioning regex which was matching the whole string between the first and last entity in the string. Adding a '?' to make the regex non-greedy restored functionality to the _fnHtmlDecode function and resolved the issue.
