### PR TITLE
Fix copied row count

### DIFF
--- a/src/TableTools.js
+++ b/src/TableTools.js
@@ -2293,7 +2293,7 @@ TableTools.BUTTONS = {
 		"fnComplete": function(nButton, oConfig, flash, text) {
 			var lines = text.split('\n').length;
             if (oConfig.bHeader) lines--;
-            if (oConfig.bFooter) lines--;
+            if (this.s.dt.nTFoot !== null && oConfig.bFooter) lines--;
 			var plural = (lines==1) ? "" : "s";
 			this.fnInfo( '<h6>Table copied</h6>'+
 				'<p>Copied '+lines+' row'+plural+' to the clipboard.</p>',


### PR DESCRIPTION
I had an issue with the row count being reported incorrectly when copying data if I altered the bHeader/bFooter options in my button config.

The existing code seemed not to account for the options passed to the button, so this commit ensures that those options are considered when determining row count to be displayed.
