### PR TITLE
Fix for defered render deselect errors

### DIFF
--- a/js/dataTables.tableTools.js
+++ b/js/dataTables.tableTools.js
@@ -1636,13 +1636,7 @@ TableTools.prototype = {
 				$(data[i].nTr).addClass( that.classes.select.row );
 			}
 		}
-		
-		// Fixed columns update
-		if ( typeof this.s.dt._oFixedColumns !== 'undefined' )
-		{
-			this.s.dt._oFixedColumns.fnUpdate();
-		}
-		
+
 		// Post-selection function
 		if ( this.s.select.postSelected !== null )
 		{
@@ -1690,12 +1684,6 @@ TableTools.prototype = {
 			{
 				$(data[i].nTr).removeClass( that.classes.select.row );
 			}
-		}
-		
-		// Fixed columns update
-		if ( typeof this.s.dt._oFixedColumns !== 'undefined' )
-		{
-			this.s.dt._oFixedColumns.fnUpdate();
 		}
 
 		// Post-deselection function


### PR DESCRIPTION
Changed fnSelectNone to match fnSelectAll which fixes defered render errors when using TableTools selection.

Errors were caused because fnGetSelected returns only TR nodes but when using defered render option we must use the aoData object.
