### PR TITLE
Selectable rows for fixed columns

### DIFF
--- a/js/dataTables.tableTools.js
+++ b/js/dataTables.tableTools.js
@@ -1497,9 +1497,9 @@ TableTools.prototype = {
 
 			// Row selection
 			$(dt.nTBody).on( 'click.DTTT_Select', this.s.custom.sRowSelector, function(e) {
-				var row = this.nodeName.toLowerCase() === 'tr' ?
-					this :
-					$(this).parents('tr')[0];
+				var row = e.delegateTarget.offsetParent.className.indexOf('DTFC_Cloned') > -1 ?
+					dt.nTBody.rows[this.rowIndex -1] :
+					this.nodeName.toLowerCase() === 'tr' ? this : $(this).parents('tr')[0];
 
 				var select = that.s.select;
 				var pos = that.s.dt.oInstance.fnGetPosition( row );


### PR DESCRIPTION
Simply adds a check if user click a row in a Fixed Column table and gets the correct row from the original datatable via row index.

Ideal with my previous pull request adding selected row CSS to Fixed Columns tables.
