### PR TITLE
_fnSelectData should accept single integers as well

### DIFF
--- a/src/TableTools.js
+++ b/src/TableTools.js
@@ -1374,6 +1374,10 @@ TableTools.prototype = {
 
 			return out;
 		}
+		else if ( typeof src === 'number' )
+		{
+		    out.push(this.s.dt.aoData[src]);
+		}
 		else
 		{
 			// A single aoData point


### PR DESCRIPTION
When trying to select a row by index using fnSelect it would not work. This was due to _fnSelectData not accepting a single integer as parameter.

Edit: I removed my other pull request as it was not commited properly and not in /src/. This one should work!
