### PR TITLE
Add !important to color property in disabled class

### DIFF
--- a/css/dataTables.tableTools.css
+++ b/css/dataTables.tableTools.css
@@ -142,7 +142,7 @@ a.DTTT_button:active:not(.DTTT_disabled) {
 button.DTTT_disabled,
 div.DTTT_disabled,
 a.DTTT_disabled {
-	color: #999;
+	color: #999 !important;
 	border: 1px solid #d0d0d0;
 	cursor: default;
 	background: #ffffff; /* Old browsers */


### PR DESCRIPTION
It is needed to add !important to color property in disabled class because of line 62, which has an !important, too.